### PR TITLE
SEO : meta description et balises alt images

### DIFF
--- a/data/tirages.yml
+++ b/data/tirages.yml
@@ -1,6 +1,7 @@
 - id: NewShinmachi
   title: "ニューシンマチ"
   year: 2024
+  alt: "ニューシンマチ — Tirage photo noir et blanc Japon 2024 Mathieu Thomasset"
   original: "tirage1.jpg"
   mockups:
   description: >
@@ -19,6 +20,7 @@
 - id: Kyoto2
   title: "Écho urbain"
   year: 2024
+  alt: "Écho urbain — Tirage photo Kyoto 2024 Mathieu Thomasset"
   original: "tirage2.jpg"
   mockups:
   description: >
@@ -37,6 +39,7 @@
 - id: SaigonSC
   title: "Saïgon social club"
   year: 2024
+  alt: "Saïgon social club — Tirage photo Vietnam 2024 Mathieu Thomasset"
   original: "tirage4.jpg"
   mockups:
   description: >

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,6 @@
 ---
 title: "Photographe en Vendée – Portrait & Reportage | Mathieu Thomasset"
-description: "Photographe portrait et reportage basé à Montaigu-Vendée. Entreprises, institutions, presse, artisanat et monde agricole : reportages, portraits corporate et savoir-faire documentés avec authenticité dans le Grand Ouest."
+description: "Mathieu Thomasset, photographe professionnel en Vendée. Portraits, reportages corporate et presse pour entreprises, institutions et médias. Basé à Montaigu, intervient dans tout le Grand Ouest."
 preferred_url: "http://www.mathieuthomasset.fr"
 ---
 
@@ -69,7 +69,7 @@ preferred_url: "http://www.mathieuthomasset.fr"
           <a href="/tirages/<%= t.id %>.html" class="tirage-link">
             <div class="tirage-square">
               <div class="tirage-frame">
-                <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: "#{t.title} — #{t.year}" %>
+                <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: t.alt || "#{t.title} — #{t.year}" %>
               </div>
             </div>
             <h3 class="tirage-title"><%= t.title %></h3>

--- a/source/tirages.html.erb
+++ b/source/tirages.html.erb
@@ -27,7 +27,7 @@ preferred_url: "http://www.mathieuthomasset.fr/tirages"
       <a href="/tirages/<%= t.id %>.html" class="tirage-link">
         <div class="tirage-square">
           <div class="tirage-frame">
-            <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: "#{t.title} — #{t.year}" %>
+            <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: t.alt || "#{t.title} — #{t.year}" %>
           </div>
         </div>
       </a>


### PR DESCRIPTION
Ferme #19

- Mise à jour de la meta description de la page d'accueil
- Ajout des balises alt détaillées sur les images tirage1, tirage2 et tirage4
- Les templates utilisent le champ alt du YAML en priorité

Generated with [Claude Code](https://claude.ai/code)