### PR TITLE
fix: Uniformiser les URLs sans extension .html

### DIFF
--- a/data/corporate.yml
+++ b/data/corporate.yml
@@ -1,89 +1,89 @@
 - picture: portrait-virage_01.jpg
-  page: viragegroup.html
+  page: viragegroup
   title: "Virage Group"
   caption: "Nantes"
   category: "Portrait"
 
 - picture: dragon_03.jpg
-  page: port-nantes-saint-nazaire.html
+  page: port-nantes-saint-nazaire
   title: "Grand Port Maritime Nantes-Saint-Nazaire"
   caption: "Nantes"
   category: "Reportage"
 
 - picture: capacites_02.jpg
-  page: capacites.html
+  page: capacites
   title: "Université de Nantes"
   caption: "Nantes"
   category: "Evénementiel"
 
 - picture: cogelec_01.jpg
-  page: cogelec.html
+  page: cogelec
   title: "Les Echos Publishing"
   caption: "Vendée"
   category: "Portrait"
 
 - picture: promus_03.jpg
-  page: promus.html
+  page: promus
   title: "Les Echos Publishing"
   caption: "Nantes"
   category: "Portrait"
 
 - picture: ouestmedialab_01.jpg
-  page: ouestmedialab.html
+  page: ouestmedialab
   title: "OuestMedialab SpeedTraining"
   caption: "Nantes"
   category: "Evénementiel"
 
 # - picture: port-nantes_03.jpg
-#   page: port-nantes-chevire.html
+#   page: port-nantes-chevire
 #   title: "Port de Nantes"
 #   caption: "Nantes"
 #   category: "Reportage"
 
 - picture: blog/tgo_01.jpg
-  page: tgo.html
+  page: tgo
   title: "Terminal Grand Ouest"
   caption: "Saint-Nazaire"
   category: "Reportage"
 
 - picture: portraitjulien-1.jpg
-  page: portraits.html
+  page: portraits
   title: "Porfolio portraits"
   caption: "Nantes"
   category: "Portrait"
 
 - picture: blog/foulee-gois-01.jpg
-  page: les-foulees-du-gois.html
+  page: les-foulees-du-gois
   title: "Les foulées du Gois"
   caption: "Noirmoutier"
   category: "Evénementiel"
 
 - picture: philharmonie_08.jpg
-  page: philharmonie.html
+  page: philharmonie
   title: "Dans les coulisses de la Philharmonie"
   caption: "Paris"
   category: "Reportage"
 
 - picture: lartdemanifester.jpg
-  page: multimedia.html
+  page: multimedia
   title: "Diaporama sonore"
   caption: ""
   category: "Reportage"
 
 - picture: pelerin_21.jpg
-  page: coulissespelerin.html
+  page: coulissespelerin
   title: "Dans les coulisses d'une rédaction"
   caption: "Montrouge"
   category: "Reportage"
 
 # - picture: marie_21.jpg
-#   page: entre-ciel-et-terre.html
+#   page: entre-ciel-et-terre
 #   title: "Marie et les filles"
 #   caption: "Saint germain-en-laye"
 #   category: "Reportage"
 
 # - picture: otto_01.jpg
-#   page: otto10.html
+#   page: otto10
 #   title: "OTTO10 : Que votre volonté soit fête !"
 #   caption: "Paris"
 #   category: "Evénementiel"

--- a/data/home.yml
+++ b/data/home.yml
@@ -16,7 +16,7 @@
   subtitle: "Presse - Corporate - Entreprise - Industrie - Artisans"
 
 # - picture: planche-contact_02B.jpg
-#   page: viragegroup.html
+#   page: viragegroup
 #   category: "PORTRAIT"
 #   title: "Portraits de salariés en studio mobile"
 
@@ -49,19 +49,19 @@
 #   caption: "Quelques semaines dans la vie de la rédaction du journal Pèlerin au contact de ceux qui font cet hebdomadaire créé en 1873 et édité par le groupe de presse indépendant Bayard."
 
 # - picture: blog/Nantes-Food-Forum_06.jpg
-#   page: nantes-food-forum-2017.html
+#   page: nantes-food-forum-2017
 #   category: "NEWS"
 #   title: "Nantes Food Forum 2017"
 #   caption: "Première édition du Nantes Food Forum autour du thème manger demain."
 
 # - picture: marseille-reborn_01.jpg
-#   page: marseille-reborn.html
+#   page: marseille-reborn
 #   category: "STORIES"
 #   title: "Marseille reborn"
 #   caption: "Le renouveau du quartier de la Joliette à Marseille, épicentre du renouveau culturel de la ville. Cet ensemble s'inscrit dans le projet Marseille Euroméditerranée, la plus grande opération de rénovation urbaine d'Europe du Sud, qui, en près de vingt, a refaçonné le visage de la ville."
 
 # - picture: tentes_01.jpg
-#   page: tentes-migrants.html
+#   page: tentes-migrants
 #   category: "NEWS"
 #   title: "Des benevoles se mobilisent pour aider les migrants"
 #   caption: "La maire de Paris, Anne Hidalgo, a annoncé la mise à disposition d’un camps humanitaire aux normes internationales pour accueillir les réfugiés d’ici à la mi septembre. En attendant des bénévoles se regroupent pour apporter une aide concrète et immédiate aux réfugiés."

--- a/data/homecards.yml
+++ b/data/homecards.yml
@@ -1,193 +1,193 @@
 # - picture: portrait_stephane-geffroy.jpg
-#   page: portraits.html
+#   page: portraits
 #   title: "Stephane Geffroy"
 #   caption: "Auteur du livre 'A l'abattoir' aux éditions Seuil"
 #   category: "Portraits"
 
 # - picture: publication_137.jpg
-#   page: vendee-globe.html
+#   page: vendee-globe
 #   title: "Vendée Globe Monochrome"
 #   caption: "Vendée"
 #   category: "Série"
 
 - picture: vendee-globe_01.jpg
-  page: vendee-globe.html
+  page: vendee-globe
   title: "Vendée Globe Monochrome"
   caption: "Vendée"
   category: "Série"
 
 - picture: portrait-jlbidet.jpg
-  page: ateliers-perrault.html 
+  page: ateliers-perrault
   title: "Portrait pour le Financial Times"
   caption: "Maine-et-Loire"
   category: "Portrait Presse"
 
 - picture: depart-vg_01.jpg
-  page: depart-vendee-globe.html
+  page: depart-vendee-globe
   title: "Départ du Vendée Globe"
   caption: "Vendée"
   category: "Presse"
 
 # - picture: LaGouriniere_Yannick_01.jpg
-#   page: portrait-yannick-vendee.html
+#   page: portrait-yannick-vendee
 #   title: "Portraits à la ferme"
 #   caption: "Vendée"
 #   category: "Portrait"
 
 # - picture: LaGouriniere_PAUL_04.jpg
-#   page: portrait-paul-vendee.html
+#   page: portrait-paul-vendee
 #   title: "Portraits à la ferme"
 #   caption: "Vendée"
 #   category: "Portrait"
 
 # - picture: LaGouriniere_Isabelle_01.jpg
-#   page: portrait-isabelle-vendee.html
+#   page: portrait-isabelle-vendee
 #   title: "Portraits à la ferme"
 #   caption: "Vendée"
 #   category: "Portrait"
 
 - picture: dragon_03.jpg
-  page: port-nantes-saint-nazaire.html
+  page: port-nantes-saint-nazaire
   title: "Grand Port Maritime de Nantes-Saint-Nazaire"
   caption: "Industrie"
   category: "Corporate"
 
 - picture: LaGouriniere_PAUL_10.jpg
-  page: portrait-michel-vendee.html
+  page: portrait-michel-vendee
   title: "Portraits à la ferme"
   caption: "Vendée"
   category: "Portrait"
 
 # - picture: LaGouriniere_Alexis-Jeremie_03.jpg
-#   page: portrait-alexisetjeremie-vendee.html
+#   page: portrait-alexisetjeremie-vendee
 #   title: "Portraits à la ferme"
 #   caption: "Vendée"
 #   category: "Portrait"
 
 # - picture: LaGouriniere_Remi_02.jpg
-#   page: portrait-remi-vendee.html
+#   page: portrait-remi-vendee
 #   title: "Portraits à la ferme"
 #   caption: "Vendée"
 #   category: "Portrait"
 
 - picture: bruno-retailleau_06.jpg
-  page: portrait-de-bruno-retailleau-pour-le-jdd.html
+  page: portrait-de-bruno-retailleau-pour-le-jdd
   title: "Portrait de Bruno Retailleau pour le JDD"
   caption: "Vendée"
   category: "Portrait Presse"
 
 
 # - picture: FT-medef_04.jpg
-#   page: portraits.html
+#   page: portraits
 #   title: "Portraits d'entrepreneurs pour le Financial Times"
 #   caption: "Vendée"
 #   category: "Portrait Presse"
 
 # - picture: confinement_02.jpg
-#   page: journal-de-confinement.html
+#   page: journal-de-confinement
 #   title: "Journal d'un confinement"
 #   caption: "Nantes"
 #   category: "Blog"
 
 # - picture: run-energie_01.jpg
-#   page: vent-vert-sur-la-reunion.html
+#   page: vent-vert-sur-la-reunion
 #   title: "Vent vert sur la Réunion"
 #   caption: "La Réunion"
 #   category: "Blog"
 
 # - picture: blog/mobilisation-pronddl_01.jpg
-#   page: mobilisation-pronddl.html
+#   page: mobilisation-pronddl
 #   title: "Mobilisation des pro-NDDL"
 #   caption: "Les riverains de l'aéroport en colère"
 #   category: "News"
 
 # - picture: ouestlajustice_01.jpg
-#   page: ou-est-la-justice.html
+#   page: ou-est-la-justice
 #   title: "Où est la Justice ?"
 #   caption: "Disparition de Steve Maia Caniço à Nantes"
 #   category: "News"
 
 # - picture: portrait_stephane-geffroy.jpg
-#   page: portraits.html
+#   page: portraits
 #   title: "Photographe portrait en Vendée"
 #   caption: "Grand Ouest"
 #   category: "Portrait"
 
 # - picture: blog/tgo_01.jpg
-#   page: terminal-grand-ouest.html
+#   page: terminal-grand-ouest
 #   title: "Terminal Grand Ouest"
 #   caption: "Saint-Nazaire"
 #   category: "Corporate"
 
 # - picture: 44BZH_01.jpg
-#   page: 44-breizh.html
+#   page: 44-breizh
 #   title: "44 = BREIZH"
 #   caption: "Nantes"
 #   category: "News"
-  
+
 # - picture: blog/chantierXXL_01.jpg
-#   page: un-chantier-xxl.html
+#   page: un-chantier-xxl
 #   title: "Un chantier XXL"
 #   caption: "Min de Nantes"
 #   category: "News"
 
 # - picture: portrait-virage_01.jpg
-#   page: viragegroup.html
+#   page: viragegroup
 #   title: "Virage Group"
 #   caption: "Nantes"
 #   category: "Corporate"
 
 # - picture: emeutes-nantes_01.jpg
-#   page: emeutes-nantes.html
+#   page: emeutes-nantes
 #   title: "Vent de révolte à Nantes"
 #   caption: "Nantes"
 #   category: "News"
 
 # - picture: blog/foulee-gois-01.jpg
-#   page: les-foulees-du-gois.html
+#   page: les-foulees-du-gois
 #   title: "Les Foulées du Gois"
 #   caption: "Noirmoutier"
 #   category: "Blog"
 
 # - picture: blog/centrale-solaire_01.jpg
-#   page: la-plus-grande-centrale-solaire-des-pays-de-la-loire.html
+#   page: la-plus-grande-centrale-solaire-des-pays-de-la-loire
 #   title: "Energie solaire"
 #   caption: "La plus grande centrale solaire des Pays de la Loire"
 #   category: "Blog"
 
 
 # - picture: blog/route-chicanes_02.jpg
-#   page: la-route-des-chicanes.html
+#   page: la-route-des-chicanes
 #   title: "La route des chicanes"
 #   caption: "Notre Dame-des-Landes"
 #   category: "News"
 
 # - picture: globetrotters-1.jpg
-#   page: globetrotters.html
+#   page: globetrotters
 #   title: "D'ici et d'ailleurs"
 #   caption: "Le retour du voyageur au long cours"
 #   category: "Portraits"
 
 # - picture: lartdemanifester.jpg
-#   page: multimedia.html
+#   page: multimedia
 #   title: "L'art de manifester"
 #   caption: "Quelle est la place de la manifestation dans notre société ?"
 #   category: "Multimedia"
 
 # - picture: blog/Nantes-Food-Forum_02.jpg
-#   page: nantes-food-forum-2017.html
+#   page: nantes-food-forum-2017
 #   title: "Nantes Food Forum"
 #   caption: "Morceaux choisis"
 #   category: "Blog"
 
 # - picture: publication_06.jpg
-#   page: publications.html
+#   page: publications
 #   title: "Grand Angle - PELERIN N°6962"
 #   caption: "Dans les coulisses du journal Pèlerin"
 #   category: "Publications"
 
 # - picture: portraitmathieu-1.jpg
-#   page: bio.html
+#   page: bio
 #   title: "Parcours et Contact"
 #   caption: "Photographe indépendant basé à Nantes"
 #   category: "Bio"

--- a/data/reportages.yml
+++ b/data/reportages.yml
@@ -1,59 +1,59 @@
 - picture: bruno-retailleau_06.jpg
-  page: portrait-de-bruno-retailleau-pour-le-jdd.html
+  page: portrait-de-bruno-retailleau-pour-le-jdd
   title: "Portrait pour le JDD"
   # caption: "Nantes"
   category: "Portrait Presse"
 - picture: ouestlajustice_01.jpg
-  page: ou-est-la-justice.html
+  page: ou-est-la-justice
   title: "Où est la Justice ?"
   # caption: "Disparition de Steve Maia Caniço"
   category: "News"
 - picture: publication_23.jpg
-  page: publications.html
+  page: publications
   title: "PUBLICATIONS"
   # caption: "Nantes"
   category: "Presse"
 - picture: marie_16.jpg
-  page: entre-ciel-et-terre.html
+  page: entre-ciel-et-terre
   title: "Marie et les filles"
   # caption: "La Réunion"
   category: "Reportage"
 - picture: pelerin_21.jpg
-  page: coulissespelerin.html
+  page: coulissespelerin
   title: "Dans les coulisses d'une rédaction"
   # caption: "La Réunion"
-  category: "Reportage"  
+  category: "Reportage"
 - picture: blog/chantierXXL_01.jpg
-  page: un-chantier-xxl.html
+  page: un-chantier-xxl
   title: "Un chantier XXL"
   # caption: "Min de Nantes"
   category: "News"
 - picture: blog/route-chicanes_02.jpg
-  page: la-route-des-chicanes.html
+  page: la-route-des-chicanes
   title: "La route des chicanes"
   # caption: "Notre Dame-des-Landes"
   category: "News"
 - picture: 44BZH_01.jpg
-  page: 44-breizh.html
+  page: 44-breizh
   title: "44 = BREIZH"
   # caption: "Nantes"
-  category: "News"  
+  category: "News"
 - picture: emeutes-nantes_01.jpg
-  page: emeutes-nantes.html
+  page: emeutes-nantes
   title: "Vent de révolte à Nantes"
   category: "News"
 - picture: blog/mobilisation-pronddl_01.jpg
-  page: mobilisation-pronddl.html
+  page: mobilisation-pronddl
   title: "Mobilisation des pro-NDDL"
   # caption: "Les riverains de l'aéroport en colère"
   category: "News"
 - picture: philharmonie_01.jpg
-  page: philharmonie.html
+  page: philharmonie
   title: "Behind the scene"
   # caption: "Les riverains de l'aéroport en colère"
   category: "Reportage"
 - picture: lartdemanifester.jpg
-  page: multimedia.html
+  page: multimedia
   title: "L'art de manifester"
   # caption: "Quelle est la place de la manifestation dans notre société ?"
   category: "Multimedia"

--- a/source/coulissespelerin.html.erb
+++ b/source/coulissespelerin.html.erb
@@ -10,12 +10,12 @@ preferred_url: "http://www.mathieuthomasset.fr/coulissespelerin"
   <div class="row">
     <div class="col-sm-9">
       <h1>Dans les coulisses du journal Pèlerin
-      <% link_to "multimedia.html" do %>
+      <% link_to "multimedia" do %>
           <i class="fa fa-play-circle-o pulse"></i>
         <% end %></h1>
       </br>
       <p>Quelques semaines dans la vie de la rédaction du journal Pèlerin au contact de ceux qui font cet hebdomadaire créé en 1873 et édité par le groupe de presse indépendant Bayard.</br>Chaque numéro mobilise une équipe de 64 personnes : 46 membres de la rédaction dont 41 journalistes, ainsi que les services communication, publicité, diffusion, fabrication...</br></br>
-      <% link_to "publications.html" do %>
+      <% link_to "publications" do %>
         <%= image_tag "publication_06.jpg", width: "150px" %>
       <%end%>
       Publication dans le Grand Angle du Pèlerin n°6962.</p>

--- a/source/demande-de-contact.html.erb
+++ b/source/demande-de-contact.html.erb
@@ -65,7 +65,7 @@ preferred_url: "http://www.mathieuthomasset.fr/demande-de-contact"
               <div class="form-group col-xs-12">
                 <label for="Message">Message *</label>
                 <textarea name="Message" id="Message" required class="form-control" rows="6"></textarea>
-                <input type="hidden" name="_next" value="http://www.mathieuthomasset.fr/confirmation-de-contact.html">
+                <input type="hidden" name="_next" value="http://www.mathieuthomasset.fr/confirmation-de-contact">
               </div>
             </div>
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -66,7 +66,7 @@ preferred_url: "http://www.mathieuthomasset.fr"
     <div class="row tirages-preview">
       <% data.tirages.first(3).each do |t| %>
         <div class="col-sm-4 tirage-card">
-          <a href="/tirages/<%= t.id %>.html" class="tirage-link">
+          <a href="/tirages/<%= t.id %>" class="tirage-link">
             <div class="tirage-square">
               <div class="tirage-frame">
                 <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: t.alt || "#{t.title} — #{t.year}" %>
@@ -78,7 +78,7 @@ preferred_url: "http://www.mathieuthomasset.fr"
         </div>
       <% end %>
     </div>
-    <a href="/tirages.html" class="btn-modern">
+    <a href="/tirages" class="btn-modern">
       <i class="fa fa-camera"></i> Voir la galerie complète
     </a>
     <div class="spacer"></div>

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -138,7 +138,7 @@ $(document).ready(function() {
       $('#selected-price').text(versionPrice);
 
       // Met à jour le bouton Commander
-      const newUrl = `/demande-de-contact.html?tirage=${encodeURIComponent(tirageName)}&label=${encodeURIComponent(versionLabel)}&prix=${encodeURIComponent(versionPrice)}`;
+      const newUrl = `/demande-de-contact?tirage=${encodeURIComponent(tirageName)}&label=${encodeURIComponent(versionLabel)}&prix=${encodeURIComponent(versionPrice)}`;
       commanderBtn.setAttribute('href', newUrl);
     }
 

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Disallow: /favicon.ico
-Disallow: /confirmation-de-contact.html
+Disallow: /confirmation-de-contact
 
 User-agent: Googlebot-Image
 Disallow:

--- a/source/tirages.html.erb
+++ b/source/tirages.html.erb
@@ -24,7 +24,7 @@ preferred_url: "http://www.mathieuthomasset.fr/tirages"
   <div class="grid-sizer"></div>
   <% data.tirages.each do |t| %>
     <div class="grid-item tirage-card">
-      <a href="/tirages/<%= t.id %>.html" class="tirage-link">
+      <a href="/tirages/<%= t.id %>" class="tirage-link">
         <div class="tirage-square">
           <div class="tirage-frame">
             <%= image_tag "tirages/#{t.original}", class: "tirage-img", alt: t.alt || "#{t.title} — #{t.year}" %>

--- a/source/tirages/template.html.erb
+++ b/source/tirages/template.html.erb
@@ -69,7 +69,7 @@
 
       <div class="spacer"></div>
       <p>
-        <% link_to "/demande-de-contact.html?tirage=#{tirage.title}", 
+        <% link_to "/demande-de-contact?tirage=#{tirage.title}",
                    class: "btn-modern", 
                    id: "commander-btn" do %>
           <i class="fa fa-cubes"></i> Commander


### PR DESCRIPTION
Suppression de l'extension .html de tous les liens internes dans les fichiers source/ et data/.

Modifications dans 11 fichiers : source/index.html.erb, tirages.html.erb, demande-de-contact.html.erb, coulissespelerin.html.erb, tirages/template.html.erb, robots.txt, javascripts/all.js, data/homecards.yml, data/corporate.yml, data/reportages.yml, data/home.yml.

Closes #24

Generated with [Claude Code](https://claude.ai/code)