### PR TITLE
SEO: passer les URLs du sitemap en https

### DIFF
--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -3,7 +3,7 @@
 
   <!-- Page d'accueil -->
   <url>
-    <loc>http://www.mathieuthomasset.fr/</loc>
+    <loc>https://www.mathieuthomasset.fr/</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
@@ -11,35 +11,35 @@
 
   <!-- Pages principales -->
   <url>
-    <loc>http://www.mathieuthomasset.fr/portraits</loc>
+    <loc>https://www.mathieuthomasset.fr/portraits</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>http://www.mathieuthomasset.fr/entreprise</loc>
+    <loc>https://www.mathieuthomasset.fr/entreprise</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>http://www.mathieuthomasset.fr/publications</loc>
+    <loc>https://www.mathieuthomasset.fr/publications</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>http://www.mathieuthomasset.fr/tirages</loc>
+    <loc>https://www.mathieuthomasset.fr/tirages</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>http://www.mathieuthomasset.fr/contact</loc>
+    <loc>https://www.mathieuthomasset.fr/contact</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -47,14 +47,14 @@
 
   <!-- Pages secondaires -->
   <url>
-    <loc>http://www.mathieuthomasset.fr/blog</loc>
+    <loc>https://www.mathieuthomasset.fr/blog</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>http://www.mathieuthomasset.fr/bio</loc>
+    <loc>https://www.mathieuthomasset.fr/bio</loc>
     <lastmod>2025-08-28</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
Remplace toutes les URLs `http://` par `https://` dans le fichier `source/sitemap.xml.erb`.

Fixes #26

Generated with [Claude Code](https://claude.ai/code)